### PR TITLE
Extend provider to support new iPXE Artifacts

### DIFF
--- a/docs/data-sources/ipxe_boot_artifact.md
+++ b/docs/data-sources/ipxe_boot_artifact.md
@@ -34,8 +34,10 @@ data "meltcloud_ipxe_boot_artifact" "example_name" {
 
 ### Read-Only
 
-- `download_url_efi` (String, Sensitive) URL to download the EFI boot artifact
+- `download_url_efi_amd64` (String, Sensitive) URL to download the amd64 EFI boot artifact
+- `download_url_efi_arm64` (String, Sensitive) URL to download the arm64 EFI boot artifact
 - `download_url_iso` (String, Sensitive) URL to download the ISO
 - `download_url_pxe` (String, Sensitive) URL to download the PCBIOS artifact (.undionly)
+- `download_url_raw_amd64` (String, Sensitive) URL to download the amd64 RAW boot artifact
 - `expires_at` (String) Timestamp when the artifact should expire
 - `status` (String) Status of the iPXE Boot Artifact

--- a/docs/data-sources/ipxe_boot_artifact.md
+++ b/docs/data-sources/ipxe_boot_artifact.md
@@ -38,6 +38,6 @@ data "meltcloud_ipxe_boot_artifact" "example_name" {
 - `download_url_efi_arm64` (String, Sensitive) URL to download the arm64 EFI boot artifact
 - `download_url_iso` (String, Sensitive) URL to download the ISO
 - `download_url_pxe` (String, Sensitive) URL to download the PCBIOS artifact (.undionly)
-- `download_url_raw_amd64` (String, Sensitive) URL to download the amd64 RAW boot artifact
+- `download_url_raw_amd64` (String, Sensitive) URL to download the amd64 Raw boot artifact
 - `expires_at` (String) Timestamp when the artifact should expire
 - `status` (String) Status of the iPXE Boot Artifact

--- a/docs/data-sources/uefi_http_boot_url.md
+++ b/docs/data-sources/uefi_http_boot_url.md
@@ -41,6 +41,8 @@ data "meltcloud_uefi_http_boot_url" "example_name" {
 ### Read-Only
 
 - `expires_at` (String) Timestamp when the URL should expire
-- `http_url` (String, Sensitive) HTTP URL of the UEFI HTTP Boot URL. Is null if protocols is set to https_only.
-- `https_url` (String, Sensitive) HTTPS URL of the UEFI HTTP Boot URL. Is null if protocols is set to http_only.
+- `http_url_amd64` (String, Sensitive) HTTP URL of the UEFI HTTP Boot URL for the amd64 architecture. Is null if protocols is set to https_only.
+- `http_url_arm64` (String, Sensitive) HTTP URL of the UEFI HTTP Boot URL for the arm64 architecture. Is null if protocols is set to https_only.
+- `https_url_amd64` (String, Sensitive) HTTPS URL of the UEFI HTTP Boot URL for the amd64 architecture. Is null if protocols is set to http_only.
+- `https_url_arm64` (String, Sensitive) HTTPS URL of the UEFI HTTP Boot URL for the arm64 architecture. Is null if protocols is set to http_only.
 - `protocols` (String) Protocols to support. Must be either http_only, https_only or http_and_https.

--- a/docs/resources/ipxe_boot_artifact.md
+++ b/docs/resources/ipxe_boot_artifact.md
@@ -56,9 +56,11 @@ resource "local_sensitive_file" "ipxe_iso" {
 
 ### Read-Only
 
-- `download_url_efi` (String, Sensitive) URL to download the EFI boot artifact
+- `download_url_efi_amd64` (String, Sensitive) URL to download the amd64 EFI boot artifact
+- `download_url_efi_arm64` (String, Sensitive) URL to download the arm64 EFI boot artifact
 - `download_url_iso` (String, Sensitive) URL to download the ISO
 - `download_url_pxe` (String, Sensitive) URL to download the PCBIOS artifact (.undionly)
+- `download_url_raw_amd64` (String, Sensitive) URL to download the amd64 RAW boot artifact
 - `id` (Number) Internal ID of the iPXE Boot Artifact
 
 ## Import

--- a/docs/resources/ipxe_boot_artifact.md
+++ b/docs/resources/ipxe_boot_artifact.md
@@ -60,7 +60,7 @@ resource "local_sensitive_file" "ipxe_iso" {
 - `download_url_efi_arm64` (String, Sensitive) URL to download the arm64 EFI boot artifact
 - `download_url_iso` (String, Sensitive) URL to download the ISO
 - `download_url_pxe` (String, Sensitive) URL to download the PCBIOS artifact (.undionly)
-- `download_url_raw_amd64` (String, Sensitive) URL to download the amd64 RAW boot artifact
+- `download_url_raw_amd64` (String, Sensitive) URL to download the amd64 Raw boot artifact
 - `id` (Number) Internal ID of the iPXE Boot Artifact
 
 ## Import

--- a/docs/resources/uefi_http_boot_url.md
+++ b/docs/resources/uefi_http_boot_url.md
@@ -67,8 +67,10 @@ output "uefi_https_boot_url" {
 
 ### Read-Only
 
-- `http_url` (String, Sensitive) HTTP URL of the UEFI HTTP Boot URL. Is null if protocols is set to https_only.
-- `https_url` (String, Sensitive) HTTPS URL of the UEFI HTTP Boot URL. Is null if protocols is set to http_only.
+- `http_url_amd64` (String, Sensitive) HTTP URL of the UEFI HTTP Boot URL for the amd64 architecture. Is null if protocols is set to https_only.
+- `http_url_arm64` (String, Sensitive) HTTP URL of the UEFI HTTP Boot URL for the arm64 architecture. Is null if protocols is set to https_only.
+- `https_url_amd64` (String, Sensitive) HTTPS URL of the UEFI HTTP Boot URL for the amd64 architecture. Is null if protocols is set to http_only.
+- `https_url_arm64` (String, Sensitive) HTTPS URL of the UEFI HTTP Boot URL for the arm64 architecture. Is null if protocols is set to http_only.
 - `id` (Number) Internal ID of the UEFI HTTP Boot URL on meltcloud
 
 ## Import

--- a/internal/client/ipxe_boot_artifact.go
+++ b/internal/client/ipxe_boot_artifact.go
@@ -20,13 +20,15 @@ type IPXEBootArtifactsResult struct {
 }
 
 type IPXEBootArtifact struct {
-	ID             int64     `json:"id"`
-	Name           string    `json:"name"`
-	ExpiresAt      time.Time `json:"expires_at"`
-	Status         string    `json:"status"`
-	DownloadURLISO string    `json:"download_url_iso"`
-	DownloadURLPXE string    `json:"download_url_pxe"`
-	DownloadURLEFI string    `json:"download_url_efi"`
+	ID                  int64     `json:"id"`
+	Name                string    `json:"name"`
+	ExpiresAt           time.Time `json:"expires_at"`
+	Status              string    `json:"status"`
+	DownloadURLISO      string    `json:"download_url_iso"`
+	DownloadURLPXE      string    `json:"download_url_pxe"`
+	DownloadURLEFIAmd64 string    `json:"download_url_efi_amd64"`
+	DownloadURLEFIArm64 string    `json:"download_url_efi_arm64"`
+	DownloadURLRawAmd64 string    `json:"download_url_raw_amd64"`
 }
 
 type IPXEBootArtifactCreateInput struct {

--- a/internal/client/ipxe_boot_artifact.go
+++ b/internal/client/ipxe_boot_artifact.go
@@ -26,9 +26,9 @@ type IPXEBootArtifact struct {
 	Status              string    `json:"status"`
 	DownloadURLISO      string    `json:"download_url_iso"`
 	DownloadURLPXE      string    `json:"download_url_pxe"`
-	DownloadURLEFIAmd64 string    `json:"download_url_efi_amd64"`
-	DownloadURLEFIArm64 string    `json:"download_url_efi_arm64"`
-	DownloadURLRawAmd64 string    `json:"download_url_raw_amd64"`
+	DownloadURLEFIAMD64 string    `json:"download_url_efi_amd64"`
+	DownloadURLEFIARM64 string    `json:"download_url_efi_arm64"`
+	DownloadURLRawAMD64 string    `json:"download_url_raw_amd64"`
 }
 
 type IPXEBootArtifactCreateInput struct {

--- a/internal/client/uefi_http_boot_url.go
+++ b/internal/client/uefi_http_boot_url.go
@@ -19,12 +19,14 @@ type UEFIHTTPBootURLsResult struct {
 }
 
 type UEFIHTTPBootURL struct {
-	ID        int64     `json:"id"`
-	Name      string    `json:"name"`
-	ExpiresAt time.Time `json:"expires_at"`
-	Protocols string    `json:"protocols"`
-	HTTPURL   string    `json:"http_url"`
-	HTTPSURL  string    `json:"https_url"`
+	ID            int64     `json:"id"`
+	Name          string    `json:"name"`
+	ExpiresAt     time.Time `json:"expires_at"`
+	Protocols     string    `json:"protocols"`
+	HTTPURLAMD64  string    `json:"http_url_amd64"`
+	HTTPSURLAMD64 string    `json:"https_url_amd64"`
+	HTTPURLARM64  string    `json:"http_url_arm64"`
+	HTTPSURLARM64 string    `json:"https_url_arm64"`
 }
 
 type UEFIHTTPBootURLCreateInput struct {

--- a/internal/provider/ipxe_boot_artifact_data_source.go
+++ b/internal/provider/ipxe_boot_artifact_data_source.go
@@ -28,13 +28,15 @@ type IPXEBootArtifactDataSource struct {
 }
 
 type IPXEBootArtifactDataSourceModel struct {
-	ID             types.Int64       `tfsdk:"id"`
-	Name           types.String      `tfsdk:"name"`
-	Status         types.String      `tfsdk:"status"`
-	ExpiresAt      timetypes.RFC3339 `tfsdk:"expires_at"`
-	DownloadURLISO types.String      `tfsdk:"download_url_iso"`
-	DownloadURLPXE types.String      `tfsdk:"download_url_pxe"`
-	DownloadURLEFI types.String      `tfsdk:"download_url_efi"`
+	ID                  types.Int64       `tfsdk:"id"`
+	Name                types.String      `tfsdk:"name"`
+	Status              types.String      `tfsdk:"status"`
+	ExpiresAt           timetypes.RFC3339 `tfsdk:"expires_at"`
+	DownloadURLISO      types.String      `tfsdk:"download_url_iso"`
+	DownloadURLPXE      types.String      `tfsdk:"download_url_pxe"`
+	DownloadURLEFIAmd64 types.String      `tfsdk:"download_url_efi_amd64"`
+	DownloadURLEFIArm64 types.String      `tfsdk:"download_url_efi_arm64"`
+	DownloadURLRawAmd64 types.String      `tfsdk:"download_url_raw_amd64"`
 }
 
 func (d *IPXEBootArtifactDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -81,8 +83,18 @@ func (d *IPXEBootArtifactDataSource) Schema(ctx context.Context, req datasource.
 				Computed:            true,
 				Sensitive:           true,
 			},
-			"download_url_efi": schema.StringAttribute{
-				MarkdownDescription: iPXEBootArtifactResourceAttributes()["download_url_efi"].GetMarkdownDescription(),
+			"download_url_efi_amd64": schema.StringAttribute{
+				MarkdownDescription: iPXEBootArtifactResourceAttributes()["download_url_efi_amd64"].GetMarkdownDescription(),
+				Computed:            true,
+				Sensitive:           true,
+			},
+			"download_url_efi_arm64": schema.StringAttribute{
+				MarkdownDescription: iPXEBootArtifactResourceAttributes()["download_url_efi_arm64"].GetMarkdownDescription(),
+				Computed:            true,
+				Sensitive:           true,
+			},
+			"download_url_raw_amd64": schema.StringAttribute{
+				MarkdownDescription: iPXEBootArtifactResourceAttributes()["download_url_raw_amd64"].GetMarkdownDescription(),
 				Computed:            true,
 				Sensitive:           true,
 			},
@@ -151,7 +163,9 @@ func (d *IPXEBootArtifactDataSource) Read(ctx context.Context, req datasource.Re
 	data.ExpiresAt = timetypes.NewRFC3339TimeValue(iPXEBootArtifact.ExpiresAt)
 	data.DownloadURLISO = types.StringValue(iPXEBootArtifact.DownloadURLISO)
 	data.DownloadURLPXE = types.StringValue(iPXEBootArtifact.DownloadURLPXE)
-	data.DownloadURLEFI = types.StringValue(iPXEBootArtifact.DownloadURLEFI)
+	data.DownloadURLEFIAmd64 = types.StringValue(iPXEBootArtifact.DownloadURLEFIAmd64)
+	data.DownloadURLEFIArm64 = types.StringValue(iPXEBootArtifact.DownloadURLEFIArm64)
+	data.DownloadURLRawAmd64 = types.StringValue(iPXEBootArtifact.DownloadURLRawAmd64)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/ipxe_boot_artifact_data_source.go
+++ b/internal/provider/ipxe_boot_artifact_data_source.go
@@ -34,9 +34,9 @@ type IPXEBootArtifactDataSourceModel struct {
 	ExpiresAt           timetypes.RFC3339 `tfsdk:"expires_at"`
 	DownloadURLISO      types.String      `tfsdk:"download_url_iso"`
 	DownloadURLPXE      types.String      `tfsdk:"download_url_pxe"`
-	DownloadURLEFIAmd64 types.String      `tfsdk:"download_url_efi_amd64"`
-	DownloadURLEFIArm64 types.String      `tfsdk:"download_url_efi_arm64"`
-	DownloadURLRawAmd64 types.String      `tfsdk:"download_url_raw_amd64"`
+	DownloadURLEFIAMD64 types.String      `tfsdk:"download_url_efi_amd64"`
+	DownloadURLEFIARM64 types.String      `tfsdk:"download_url_efi_arm64"`
+	DownloadURLRawAMD64 types.String      `tfsdk:"download_url_raw_amd64"`
 }
 
 func (d *IPXEBootArtifactDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -163,9 +163,9 @@ func (d *IPXEBootArtifactDataSource) Read(ctx context.Context, req datasource.Re
 	data.ExpiresAt = timetypes.NewRFC3339TimeValue(iPXEBootArtifact.ExpiresAt)
 	data.DownloadURLISO = types.StringValue(iPXEBootArtifact.DownloadURLISO)
 	data.DownloadURLPXE = types.StringValue(iPXEBootArtifact.DownloadURLPXE)
-	data.DownloadURLEFIAmd64 = types.StringValue(iPXEBootArtifact.DownloadURLEFIAmd64)
-	data.DownloadURLEFIArm64 = types.StringValue(iPXEBootArtifact.DownloadURLEFIArm64)
-	data.DownloadURLRawAmd64 = types.StringValue(iPXEBootArtifact.DownloadURLRawAmd64)
+	data.DownloadURLEFIAMD64 = types.StringValue(iPXEBootArtifact.DownloadURLEFIAMD64)
+	data.DownloadURLEFIARM64 = types.StringValue(iPXEBootArtifact.DownloadURLEFIARM64)
+	data.DownloadURLRawAMD64 = types.StringValue(iPXEBootArtifact.DownloadURLRawAMD64)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/ipxe_boot_artifact_resource.go
+++ b/internal/provider/ipxe_boot_artifact_resource.go
@@ -142,12 +142,12 @@ func (r *IPXEBootArtifactResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
-	ipxeBootArtifactCreateInput := &client.IPXEBootArtifactCreateInput{
+	iPXEBootArtifactCreateInput := &client.IPXEBootArtifactCreateInput{
 		ExpiresAt: expiresAt.UTC(),
 		Name:      name,
 	}
 
-	result, err := r.client.IPXEBootArtifact().Create(ctx, ipxeBootArtifactCreateInput)
+	result, err := r.client.IPXEBootArtifact().Create(ctx, iPXEBootArtifactCreateInput)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create ipxe boot artifact, got error: %s", err))
 		return

--- a/internal/provider/ipxe_boot_artifact_resource.go
+++ b/internal/provider/ipxe_boot_artifact_resource.go
@@ -37,9 +37,9 @@ type IPXEBootArtifactResourceModel struct {
 	ExpiresAt           timetypes.RFC3339 `tfsdk:"expires_at"`
 	DownloadURLISO      types.String      `tfsdk:"download_url_iso"`
 	DownloadURLPXE      types.String      `tfsdk:"download_url_pxe"`
-	DownloadURLEFIAmd64 types.String      `tfsdk:"download_url_efi_amd64"`
-	DownloadURLEFIArm64 types.String      `tfsdk:"download_url_efi_arm64"`
-	DownloadURLRawAmd64 types.String      `tfsdk:"download_url_raw_amd64"`
+	DownloadURLEFIAMD64 types.String      `tfsdk:"download_url_efi_amd64"`
+	DownloadURLEFIARM64 types.String      `tfsdk:"download_url_efi_arm64"`
+	DownloadURLRawAMD64 types.String      `tfsdk:"download_url_raw_amd64"`
 }
 
 func (r *IPXEBootArtifactResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -93,7 +93,7 @@ func iPXEBootArtifactResourceAttributes() map[string]schema.Attribute {
 			Sensitive:           true,
 		},
 		"download_url_raw_amd64": schema.StringAttribute{
-			MarkdownDescription: "URL to download the amd64 RAW boot artifact",
+			MarkdownDescription: "URL to download the amd64 Raw boot artifact",
 			Computed:            true,
 			Sensitive:           true,
 		},
@@ -172,9 +172,9 @@ func (r *IPXEBootArtifactResource) Create(ctx context.Context, req resource.Crea
 	data.ID = types.Int64Value(result.IPXEBootArtifact.ID)
 	data.DownloadURLISO = types.StringValue(result.IPXEBootArtifact.DownloadURLISO)
 	data.DownloadURLPXE = types.StringValue(result.IPXEBootArtifact.DownloadURLPXE)
-	data.DownloadURLEFIAmd64 = types.StringValue(result.IPXEBootArtifact.DownloadURLEFIAmd64)
-	data.DownloadURLEFIArm64 = types.StringValue(result.IPXEBootArtifact.DownloadURLEFIArm64)
-	data.DownloadURLRawAmd64 = types.StringValue(result.IPXEBootArtifact.DownloadURLRawAmd64)
+	data.DownloadURLEFIAMD64 = types.StringValue(result.IPXEBootArtifact.DownloadURLEFIAMD64)
+	data.DownloadURLEFIARM64 = types.StringValue(result.IPXEBootArtifact.DownloadURLEFIARM64)
+	data.DownloadURLRawAMD64 = types.StringValue(result.IPXEBootArtifact.DownloadURLRawAMD64)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -197,9 +197,9 @@ func (r *IPXEBootArtifactResource) Read(ctx context.Context, req resource.ReadRe
 	data.ExpiresAt = timetypes.NewRFC3339TimeValue(result.IPXEBootArtifact.ExpiresAt.UTC())
 	data.DownloadURLISO = types.StringValue(result.IPXEBootArtifact.DownloadURLISO)
 	data.DownloadURLPXE = types.StringValue(result.IPXEBootArtifact.DownloadURLPXE)
-	data.DownloadURLEFIAmd64 = types.StringValue(result.IPXEBootArtifact.DownloadURLEFIAmd64)
-	data.DownloadURLEFIArm64 = types.StringValue(result.IPXEBootArtifact.DownloadURLEFIArm64)
-	data.DownloadURLRawAmd64 = types.StringValue(result.IPXEBootArtifact.DownloadURLRawAmd64)
+	data.DownloadURLEFIAMD64 = types.StringValue(result.IPXEBootArtifact.DownloadURLEFIAMD64)
+	data.DownloadURLEFIARM64 = types.StringValue(result.IPXEBootArtifact.DownloadURLEFIARM64)
+	data.DownloadURLRawAMD64 = types.StringValue(result.IPXEBootArtifact.DownloadURLRawAMD64)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/ipxe_boot_artifact_resource.go
+++ b/internal/provider/ipxe_boot_artifact_resource.go
@@ -32,12 +32,14 @@ type IPXEBootArtifactResource struct {
 
 // IPXEBootArtifactResourceModel describes the resource data model.
 type IPXEBootArtifactResourceModel struct {
-	ID             types.Int64       `tfsdk:"id"`
-	Name           types.String      `tfsdk:"name"`
-	ExpiresAt      timetypes.RFC3339 `tfsdk:"expires_at"`
-	DownloadURLISO types.String      `tfsdk:"download_url_iso"`
-	DownloadURLPXE types.String      `tfsdk:"download_url_pxe"`
-	DownloadURLEFI types.String      `tfsdk:"download_url_efi"`
+	ID                  types.Int64       `tfsdk:"id"`
+	Name                types.String      `tfsdk:"name"`
+	ExpiresAt           timetypes.RFC3339 `tfsdk:"expires_at"`
+	DownloadURLISO      types.String      `tfsdk:"download_url_iso"`
+	DownloadURLPXE      types.String      `tfsdk:"download_url_pxe"`
+	DownloadURLEFIAmd64 types.String      `tfsdk:"download_url_efi_amd64"`
+	DownloadURLEFIArm64 types.String      `tfsdk:"download_url_efi_arm64"`
+	DownloadURLRawAmd64 types.String      `tfsdk:"download_url_raw_amd64"`
 }
 
 func (r *IPXEBootArtifactResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -80,8 +82,18 @@ func iPXEBootArtifactResourceAttributes() map[string]schema.Attribute {
 			Computed:            true,
 			Sensitive:           true,
 		},
-		"download_url_efi": schema.StringAttribute{
-			MarkdownDescription: "URL to download the EFI boot artifact",
+		"download_url_efi_amd64": schema.StringAttribute{
+			MarkdownDescription: "URL to download the amd64 EFI boot artifact",
+			Computed:            true,
+			Sensitive:           true,
+		},
+		"download_url_efi_arm64": schema.StringAttribute{
+			MarkdownDescription: "URL to download the arm64 EFI boot artifact",
+			Computed:            true,
+			Sensitive:           true,
+		},
+		"download_url_raw_amd64": schema.StringAttribute{
+			MarkdownDescription: "URL to download the amd64 RAW boot artifact",
 			Computed:            true,
 			Sensitive:           true,
 		},
@@ -160,7 +172,9 @@ func (r *IPXEBootArtifactResource) Create(ctx context.Context, req resource.Crea
 	data.ID = types.Int64Value(result.IPXEBootArtifact.ID)
 	data.DownloadURLISO = types.StringValue(result.IPXEBootArtifact.DownloadURLISO)
 	data.DownloadURLPXE = types.StringValue(result.IPXEBootArtifact.DownloadURLPXE)
-	data.DownloadURLEFI = types.StringValue(result.IPXEBootArtifact.DownloadURLEFI)
+	data.DownloadURLEFIAmd64 = types.StringValue(result.IPXEBootArtifact.DownloadURLEFIAmd64)
+	data.DownloadURLEFIArm64 = types.StringValue(result.IPXEBootArtifact.DownloadURLEFIArm64)
+	data.DownloadURLRawAmd64 = types.StringValue(result.IPXEBootArtifact.DownloadURLRawAmd64)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -183,7 +197,9 @@ func (r *IPXEBootArtifactResource) Read(ctx context.Context, req resource.ReadRe
 	data.ExpiresAt = timetypes.NewRFC3339TimeValue(result.IPXEBootArtifact.ExpiresAt.UTC())
 	data.DownloadURLISO = types.StringValue(result.IPXEBootArtifact.DownloadURLISO)
 	data.DownloadURLPXE = types.StringValue(result.IPXEBootArtifact.DownloadURLPXE)
-	data.DownloadURLEFI = types.StringValue(result.IPXEBootArtifact.DownloadURLEFI)
+	data.DownloadURLEFIAmd64 = types.StringValue(result.IPXEBootArtifact.DownloadURLEFIAmd64)
+	data.DownloadURLEFIArm64 = types.StringValue(result.IPXEBootArtifact.DownloadURLEFIArm64)
+	data.DownloadURLRawAmd64 = types.StringValue(result.IPXEBootArtifact.DownloadURLRawAmd64)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/uefi_http_boot_url_data_source.go
+++ b/internal/provider/uefi_http_boot_url_data_source.go
@@ -31,11 +31,13 @@ type UEFIHTTPBootURLDataSourceModel struct {
 	ID                 types.Int64 `tfsdk:"id"`
 	IPXEBootArtifactID types.Int64 `tfsdk:"ipxe_boot_artifact_id"`
 
-	Name      types.String      `tfsdk:"name"`
-	ExpiresAt timetypes.RFC3339 `tfsdk:"expires_at"`
-	Protocols types.String      `tfsdk:"protocols"`
-	HTTPURL   types.String      `tfsdk:"http_url"`
-	HTTPSURL  types.String      `tfsdk:"https_url"`
+	Name          types.String      `tfsdk:"name"`
+	ExpiresAt     timetypes.RFC3339 `tfsdk:"expires_at"`
+	Protocols     types.String      `tfsdk:"protocols"`
+	HTTPURLAMD64  types.String      `tfsdk:"http_url_amd64"`
+	HTTPURLARM64  types.String      `tfsdk:"http_url_arm64"`
+	HTTPSURLAMD64 types.String      `tfsdk:"https_url_amd64"`
+	HTTPSURLARM64 types.String      `tfsdk:"https_url_arm64"`
 }
 
 func (d *UEFIHTTPBootURLDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -76,13 +78,23 @@ func (d *UEFIHTTPBootURLDataSource) Schema(ctx context.Context, req datasource.S
 				MarkdownDescription: uefiHTTPBootURLResourceAttributes()["expires_at"].GetMarkdownDescription(),
 				Computed:            true,
 			},
-			"http_url": schema.StringAttribute{
-				MarkdownDescription: uefiHTTPBootURLResourceAttributes()["http_url"].GetMarkdownDescription(),
+			"http_url_amd64": schema.StringAttribute{
+				MarkdownDescription: uefiHTTPBootURLResourceAttributes()["http_url_amd64"].GetMarkdownDescription(),
 				Computed:            true,
 				Sensitive:           true,
 			},
-			"https_url": schema.StringAttribute{
-				MarkdownDescription: uefiHTTPBootURLResourceAttributes()["https_url"].GetMarkdownDescription(),
+			"http_url_arm64": schema.StringAttribute{
+				MarkdownDescription: uefiHTTPBootURLResourceAttributes()["http_url_arm64"].GetMarkdownDescription(),
+				Computed:            true,
+				Sensitive:           true,
+			},
+			"https_url_amd64": schema.StringAttribute{
+				MarkdownDescription: uefiHTTPBootURLResourceAttributes()["https_url_amd64"].GetMarkdownDescription(),
+				Computed:            true,
+				Sensitive:           true,
+			},
+			"https_url_arm64": schema.StringAttribute{
+				MarkdownDescription: uefiHTTPBootURLResourceAttributes()["https_url_arm64"].GetMarkdownDescription(),
 				Computed:            true,
 				Sensitive:           true,
 			},
@@ -149,8 +161,10 @@ func (d *UEFIHTTPBootURLDataSource) Read(ctx context.Context, req datasource.Rea
 	data.Name = types.StringValue(uefiHTTPBootURL.Name)
 	data.Protocols = types.StringValue(uefiHTTPBootURL.Protocols)
 	data.ExpiresAt = timetypes.NewRFC3339TimeValue(uefiHTTPBootURL.ExpiresAt)
-	data.HTTPURL = types.StringValue(uefiHTTPBootURL.HTTPURL)
-	data.HTTPSURL = types.StringValue(uefiHTTPBootURL.HTTPSURL)
+	data.HTTPURLAMD64 = types.StringValue(uefiHTTPBootURL.HTTPURLAMD64)
+	data.HTTPURLARM64 = types.StringValue(uefiHTTPBootURL.HTTPURLARM64)
+	data.HTTPSURLAMD64 = types.StringValue(uefiHTTPBootURL.HTTPSURLAMD64)
+	data.HTTPSURLARM64 = types.StringValue(uefiHTTPBootURL.HTTPSURLARM64)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/uefi_http_boot_url_resource.go
+++ b/internal/provider/uefi_http_boot_url_resource.go
@@ -35,11 +35,13 @@ type UEFIHTTPBootURLResourceModel struct {
 	ID                 types.Int64 `tfsdk:"id"`
 	IPXEBootArtifactID types.Int64 `tfsdk:"ipxe_boot_artifact_id"`
 
-	Name      types.String      `tfsdk:"name"`
-	ExpiresAt timetypes.RFC3339 `tfsdk:"expires_at"`
-	Protocols types.String      `tfsdk:"protocols"`
-	HTTPURL   types.String      `tfsdk:"http_url"`
-	HTTPSURL  types.String      `tfsdk:"https_url"`
+	Name          types.String      `tfsdk:"name"`
+	ExpiresAt     timetypes.RFC3339 `tfsdk:"expires_at"`
+	Protocols     types.String      `tfsdk:"protocols"`
+	HTTPURLAMD64  types.String      `tfsdk:"http_url_amd64"`
+	HTTPURLARM64  types.String      `tfsdk:"http_url_arm64"`
+	HTTPSURLAMD64 types.String      `tfsdk:"https_url_amd64"`
+	HTTPSURLARM64 types.String      `tfsdk:"https_url_arm64"`
 }
 
 func (r *UEFIHTTPBootURLResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -86,13 +88,23 @@ func uefiHTTPBootURLResourceAttributes() map[string]schema.Attribute {
 				stringplanmodifier.RequiresReplace(),
 			},
 		},
-		"http_url": schema.StringAttribute{
-			MarkdownDescription: "HTTP URL of the UEFI HTTP Boot URL. Is null if protocols is set to https_only.",
+		"http_url_amd64": schema.StringAttribute{
+			MarkdownDescription: "HTTP URL of the UEFI HTTP Boot URL for the amd64 architecture. Is null if protocols is set to https_only.",
 			Computed:            true,
 			Sensitive:           true,
 		},
-		"https_url": schema.StringAttribute{
-			MarkdownDescription: "HTTPS URL of the UEFI HTTP Boot URL. Is null if protocols is set to http_only.",
+		"http_url_arm64": schema.StringAttribute{
+			MarkdownDescription: "HTTP URL of the UEFI HTTP Boot URL for the arm64 architecture. Is null if protocols is set to https_only.",
+			Computed:            true,
+			Sensitive:           true,
+		},
+		"https_url_amd64": schema.StringAttribute{
+			MarkdownDescription: "HTTPS URL of the UEFI HTTP Boot URL for the amd64 architecture. Is null if protocols is set to http_only.",
+			Computed:            true,
+			Sensitive:           true,
+		},
+		"https_url_arm64": schema.StringAttribute{
+			MarkdownDescription: "HTTPS URL of the UEFI HTTP Boot URL for the arm64 architecture. Is null if protocols is set to http_only.",
 			Computed:            true,
 			Sensitive:           true,
 		},
@@ -153,8 +165,10 @@ func (r *UEFIHTTPBootURLResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	data.ID = types.Int64Value(result.UEFIHTTPBootURL.ID)
-	data.HTTPURL = types.StringValue(result.UEFIHTTPBootURL.HTTPURL)
-	data.HTTPSURL = types.StringValue(result.UEFIHTTPBootURL.HTTPSURL)
+	data.HTTPURLAMD64 = types.StringValue(result.UEFIHTTPBootURL.HTTPURLAMD64)
+	data.HTTPURLARM64 = types.StringValue(result.UEFIHTTPBootURL.HTTPURLARM64)
+	data.HTTPSURLAMD64 = types.StringValue(result.UEFIHTTPBootURL.HTTPSURLAMD64)
+	data.HTTPSURLARM64 = types.StringValue(result.UEFIHTTPBootURL.HTTPSURLARM64)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -176,8 +190,10 @@ func (r *UEFIHTTPBootURLResource) Read(ctx context.Context, req resource.ReadReq
 	data.Name = types.StringValue(result.UEFIHTTPBootURL.Name)
 	data.Protocols = types.StringValue(result.UEFIHTTPBootURL.Protocols)
 	data.ExpiresAt = timetypes.NewRFC3339TimeValue(result.UEFIHTTPBootURL.ExpiresAt.UTC())
-	data.HTTPURL = types.StringValue(result.UEFIHTTPBootURL.HTTPURL)
-	data.HTTPSURL = types.StringValue(result.UEFIHTTPBootURL.HTTPSURL)
+	data.HTTPURLAMD64 = types.StringValue(result.UEFIHTTPBootURL.HTTPURLAMD64)
+	data.HTTPURLARM64 = types.StringValue(result.UEFIHTTPBootURL.HTTPURLARM64)
+	data.HTTPSURLAMD64 = types.StringValue(result.UEFIHTTPBootURL.HTTPSURLAMD64)
+	data.HTTPSURLARM64 = types.StringValue(result.UEFIHTTPBootURL.HTTPSURLARM64)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }


### PR DESCRIPTION
This PR introduces support for new iPXE boot artifacts.
- arm64 based EFI
- amd64 based EFI
- amd64 based RAW bootable disk image