### PR TITLE
feat: add TLS configuration for self-hosted deployments

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,10 +22,22 @@ terraform {
   }
 }
 
+# Cloud-hosted meltcloud
 provider "meltcloud" {
   endpoint     = "https://app.meltcloud.io" # optional
   organization = "deadbeef-0000-0000-0000-000000000000"
   api_key      = "eyJf..." # better pass it via env var MELTCLOUD_API_KEY or a tfvars file
+}
+
+# Self-hosted Foundry with a private CA certificate
+provider "meltcloud" {
+  alias        = "self_hosted"
+  endpoint     = "https://app.foundry.example.com"
+  organization = "deadbeef-0000-0000-0000-000000000000"
+  api_key      = "eyJf..."
+
+  ca_cert_file = "/path/to/foundry-ca.pem" # or use MELTCLOUD_CACERT env var
+  # ca_cert_pem = "-----BEGIN CERTIFICATE-----\n..." # alternative: inline PEM
 }
 
 # Create a cluster
@@ -44,4 +56,7 @@ resource "meltcloud_cluster" "example" {
 ### Optional
 
 - `api_key` (String) API Key permitted for the organization. Can also be set via MELTCLOUD_API_KEY environment variable.
+- `ca_cert_file` (String) Path to a CA certificate file to verify the meltcloud API server's TLS certificate. Conflicts with `ca_cert_pem`. Can also be set via MELTCLOUD_CACERT environment variable.
+- `ca_cert_pem` (String) PEM-encoded CA certificate to verify the meltcloud API server's TLS certificate. Conflicts with `ca_cert_file`.
 - `endpoint` (String) URL of the meltcloud API, defaults to https://app.meltcloud.io. Can also be set via MELTCLOUD_ENDPOINT environment variable.
+- `skip_tls_verify` (Boolean) Skip TLS certificate verification. Can also be set via MELTCLOUD_SKIP_VERIFY environment variable.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -7,10 +7,22 @@ terraform {
   }
 }
 
+# Cloud-hosted meltcloud
 provider "meltcloud" {
   endpoint     = "https://app.meltcloud.io" # optional
   organization = "deadbeef-0000-0000-0000-000000000000"
   api_key      = "eyJf..." # better pass it via env var MELTCLOUD_API_KEY or a tfvars file
+}
+
+# Self-hosted Foundry with a private CA certificate
+provider "meltcloud" {
+  alias        = "self_hosted"
+  endpoint     = "https://app.foundry.example.com"
+  organization = "deadbeef-0000-0000-0000-000000000000"
+  api_key      = "eyJf..."
+
+  ca_cert_file = "/path/to/foundry-ca.pem" # or use MELTCLOUD_CACERT env var
+  # ca_cert_pem = "-----BEGIN CERTIFICATE-----\n..." # alternative: inline PEM
 }
 
 # Create a cluster

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 
 	"github.com/go-resty/resty/v2"
@@ -31,7 +33,12 @@ type Metadata struct {
 	TotalCount  int `json:"total_count,omitempty"`
 }
 
-func New(endpoint string, organization string, apiKey string) *Client {
+type TLSConfig struct {
+	CACertPEM     string
+	SkipTLSVerify bool
+}
+
+func New(endpoint string, organization string, apiKey string, tlsConfig *TLSConfig) *Client {
 	url := fmt.Sprintf("%s%s/orgs/%s/", endpoint, apiPath, organization)
 
 	restyClient := resty.New().
@@ -39,6 +46,19 @@ func New(endpoint string, organization string, apiKey string) *Client {
 		SetHeader("Content-Type", "application/json").
 		SetHeader("User-Agent", "meltcloud-go-client v1").
 		SetHeader("X-Meltcloud-API-Key", apiKey)
+
+	if tlsConfig != nil {
+		tc := &tls.Config{}
+		if tlsConfig.SkipTLSVerify {
+			tc.InsecureSkipVerify = true
+		}
+		if tlsConfig.CACertPEM != "" {
+			pool := x509.NewCertPool()
+			pool.AppendCertsFromPEM([]byte(tlsConfig.CACertPEM))
+			tc.RootCAs = pool
+		}
+		restyClient.SetTLSClientConfig(tc)
+	}
 
 	return &Client{
 		HttpClient:   restyClient,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"terraform-provider-meltcloud/internal/client"
 
@@ -27,9 +28,12 @@ type MeltcloudProvider struct {
 
 // MeltcloudProviderModel describes the provider data model.
 type MeltcloudProviderModel struct {
-	Endpoint     types.String `tfsdk:"endpoint"`
-	Organization types.String `tfsdk:"organization"`
-	APIKey       types.String `tfsdk:"api_key"`
+	Endpoint      types.String `tfsdk:"endpoint"`
+	Organization  types.String `tfsdk:"organization"`
+	APIKey        types.String `tfsdk:"api_key"`
+	CACertFile    types.String `tfsdk:"ca_cert_file"`
+	CACertPEM     types.String `tfsdk:"ca_cert_pem"`
+	SkipTLSVerify types.Bool   `tfsdk:"skip_tls_verify"`
 }
 
 func (p *MeltcloudProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -50,6 +54,18 @@ func (p *MeltcloudProvider) Schema(ctx context.Context, req provider.SchemaReque
 			},
 			"api_key": schema.StringAttribute{
 				MarkdownDescription: "API Key permitted for the organization. Can also be set via MELTCLOUD_API_KEY environment variable.",
+				Optional:            true,
+			},
+			"ca_cert_file": schema.StringAttribute{
+				MarkdownDescription: "Path to a CA certificate file to verify the meltcloud API server's TLS certificate. Conflicts with `ca_cert_pem`. Can also be set via MELTCLOUD_CACERT environment variable.",
+				Optional:            true,
+			},
+			"ca_cert_pem": schema.StringAttribute{
+				MarkdownDescription: "PEM-encoded CA certificate to verify the meltcloud API server's TLS certificate. Conflicts with `ca_cert_file`.",
+				Optional:            true,
+			},
+			"skip_tls_verify": schema.BoolAttribute{
+				MarkdownDescription: "Skip TLS certificate verification. Can also be set via MELTCLOUD_SKIP_VERIFY environment variable.",
 				Optional:            true,
 			},
 		},
@@ -97,10 +113,34 @@ func (p *MeltcloudProvider) Configure(ctx context.Context, req provider.Configur
 		organization = data.Organization.ValueString()
 	}
 
-	apiClient := client.New(endpoint, organization, apiKey)
-	// Set debug flag to log http traffic to foundry, but disable before releasing
-	// as it creates "unexpected output" warnings in the terraform log.
-	// apiClient.HttpClient.Debug = true
+	var tlsConfig *client.TLSConfig
+
+	caFile := stringAttrOrEnv(data.CACertFile, "MELTCLOUD_CACERT")
+	caPEM := stringAttrOrEmpty(data.CACertPEM)
+	skipTLS := boolAttrOrEnv(data.SkipTLSVerify, "MELTCLOUD_SKIP_VERIFY")
+
+	if caFile != "" && caPEM != "" {
+		resp.Diagnostics.AddError("Config Error", "ca_cert_file and ca_cert_pem are mutually exclusive")
+		return
+	}
+
+	if caFile != "" {
+		pemBytes, err := os.ReadFile(caFile)
+		if err != nil {
+			resp.Diagnostics.AddError("Config Error", fmt.Sprintf("failed to read CA certificate file: %s", err))
+			return
+		}
+		caPEM = string(pemBytes)
+	}
+
+	if caPEM != "" || skipTLS {
+		tlsConfig = &client.TLSConfig{
+			CACertPEM:     caPEM,
+			SkipTLSVerify: skipTLS,
+		}
+	}
+
+	apiClient := client.New(endpoint, organization, apiKey, tlsConfig)
 	resp.DataSourceData = apiClient
 	resp.ResourceData = apiClient
 }
@@ -141,4 +181,26 @@ func New(version string) func() provider.Provider {
 			version: version,
 		}
 	}
+}
+
+func stringAttrOrEnv(attr types.String, envVar string) string {
+	if !attr.IsNull() {
+		return attr.ValueString()
+	}
+	return os.Getenv(envVar)
+}
+
+func stringAttrOrEmpty(attr types.String) string {
+	if !attr.IsNull() {
+		return attr.ValueString()
+	}
+	return ""
+}
+
+func boolAttrOrEnv(attr types.Bool, envVar string) bool {
+	if !attr.IsNull() {
+		return attr.ValueBool()
+	}
+	v := os.Getenv(envVar)
+	return v == "1" || v == "true"
 }


### PR DESCRIPTION
## Summary
- Adds `ca_cert_file`, `ca_cert_pem`, and `skip_tls_verify` provider attributes for self-hosted Foundry deployments with private CA certificates
- `ca_cert_file` and `ca_cert_pem` are mutually exclusive (follows Nomad/Consul pattern)
- Env var fallback: `MELTCLOUD_CACERT` for CA cert file path, `MELTCLOUD_SKIP_VERIFY` for skipping verification
- Fixes `x509: certificate is not standards compliant` errors on macOS when connecting to Foundry instances with long-lived TLS certificates

## Usage

```hcl
provider "meltcloud" {
  endpoint     = "https://app.192.168.1.100.d.meltcloud.io"
  organization = "..."
  api_key      = "..."

  # Option A: path to CA cert file
  ca_cert_file = "/path/to/foundry-ca.pem"

  # Option B: inline PEM (conflicts with ca_cert_file)
  # ca_cert_pem = "-----BEGIN CERTIFICATE-----\n..."

  # Option C: skip verification entirely (not recommended for production)
  # skip_tls_verify = true
}
```

## Test plan
- [x] `go build ./...` passes
- [ ] Manual test with self-hosted Foundry using `ca_cert_file`
- [ ] Manual test with `skip_tls_verify = true`
- [ ] Manual test with `MELTCLOUD_CACERT` env var