### PR TITLE
Update docs links and elastic resource descriptions

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -3,12 +3,12 @@
 page_title: "meltcloud_cluster Data Source - meltcloud"
 subcategory: ""
 description: |-
-  A Cluster https://docs.meltcloud.io/guides/clusters/create.html in meltcloud consists of a Kubernetes Control Plane and associated objects like Machine Pools https://docs.meltcloud.io/guides/machine-pools/create.html (which hold assigned Machines https://docs.meltcloud.io/concepts/machines).
+  A Cluster https://docs.meltcloud.io/tasks/clusters/create in meltcloud consists of a Kubernetes Control Plane and associated objects like Machine Pools https://docs.meltcloud.io/tasks/machine-pools/create (which hold assigned Machines https://docs.meltcloud.io/concepts/machines).
 ---
 
 # meltcloud_cluster (Data Source)
 
-A [Cluster](https://docs.meltcloud.io/guides/clusters/create.html) in meltcloud consists of a **Kubernetes Control Plane** and associated objects like [Machine Pools](https://docs.meltcloud.io/guides/machine-pools/create.html) (which hold assigned [Machines](https://docs.meltcloud.io/concepts/machines)).
+A [Cluster](https://docs.meltcloud.io/tasks/clusters/create) in meltcloud consists of a **Kubernetes Control Plane** and associated objects like [Machine Pools](https://docs.meltcloud.io/tasks/machine-pools/create) (which hold assigned [Machines](https://docs.meltcloud.io/concepts/machines)).
 
 ## Example Usage
 

--- a/docs/data-sources/elastic_fleet.md
+++ b/docs/data-sources/elastic_fleet.md
@@ -3,12 +3,12 @@
 page_title: "meltcloud_elastic_fleet Data Source - meltcloud"
 subcategory: ""
 description: |-
-  An Elastic Fleet is a pool of compute resources on a cluster which can be sliced into Elastic Quotas for consumption by other organizations.
+  An Elastic Fleet https://docs.meltcloud.io/concepts/elastic-node-pools#elastic-fleet turns a Machine Pool into virtualization capacity. Resources can be allocated to organizations via Elastic Quotas https://docs.meltcloud.io/tasks/elastic-fleets/create-quota, and Elastic Nodes (virtual Kubernetes worker nodes) can be added to Clusters via Elastic Node Pools https://docs.meltcloud.io/tasks/elastic-node-pools/create.
 ---
 
 # meltcloud_elastic_fleet (Data Source)
 
-An Elastic Fleet is a pool of compute resources on a cluster which can be sliced into Elastic Quotas for consumption by other organizations.
+An [Elastic Fleet](https://docs.meltcloud.io/concepts/elastic-node-pools#elastic-fleet) turns a Machine Pool into virtualization capacity. Resources can be allocated to organizations via [Elastic Quotas](https://docs.meltcloud.io/tasks/elastic-fleets/create-quota), and Elastic Nodes (virtual Kubernetes worker nodes) can be added to Clusters via [Elastic Node Pools](https://docs.meltcloud.io/tasks/elastic-node-pools/create).
 
 ## Example Usage
 

--- a/docs/data-sources/elastic_node_pool.md
+++ b/docs/data-sources/elastic_node_pool.md
@@ -3,12 +3,12 @@
 page_title: "meltcloud_elastic_node_pool Data Source - meltcloud"
 subcategory: ""
 description: |-
-  An Elastic Node Pool is a grouping of Elastic Fleet nodes scheduled into a consuming organization's cluster, sized via node count and per-node resources.
+  An Elastic Node Pool https://docs.meltcloud.io/tasks/elastic-node-pools/create provisions Elastic Nodes (virtual Kubernetes worker nodes) from an Elastic Quota https://docs.meltcloud.io/tasks/elastic-fleets/create-quota and joins them to a Cluster.
 ---
 
 # meltcloud_elastic_node_pool (Data Source)
 
-An Elastic Node Pool is a grouping of Elastic Fleet nodes scheduled into a consuming organization's cluster, sized via node count and per-node resources.
+An [Elastic Node Pool](https://docs.meltcloud.io/tasks/elastic-node-pools/create) provisions Elastic Nodes (virtual Kubernetes worker nodes) from an [Elastic Quota](https://docs.meltcloud.io/tasks/elastic-fleets/create-quota) and joins them to a Cluster.
 
 ## Example Usage
 

--- a/docs/data-sources/elastic_quota.md
+++ b/docs/data-sources/elastic_quota.md
@@ -3,12 +3,12 @@
 page_title: "meltcloud_elastic_quota Data Source - meltcloud"
 subcategory: ""
 description: |-
-  An Elastic Quota grants a consuming organization a slice of an Elastic Fleet, expressed in cores, memory, and disk.
+  An Elastic Quota https://docs.meltcloud.io/tasks/elastic-fleets/create-quota allocates a portion of an Elastic Fleet https://docs.meltcloud.io/concepts/elastic-node-pools#elastic-fleet's resources (CPU, RAM, disk) to a consuming organization.
 ---
 
 # meltcloud_elastic_quota (Data Source)
 
-An Elastic Quota grants a consuming organization a slice of an Elastic Fleet, expressed in cores, memory, and disk.
+An [Elastic Quota](https://docs.meltcloud.io/tasks/elastic-fleets/create-quota) allocates a portion of an [Elastic Fleet](https://docs.meltcloud.io/concepts/elastic-node-pools#elastic-fleet)'s resources (CPU, RAM, disk) to a consuming organization.
 
 ## Example Usage
 

--- a/docs/data-sources/enrollment_image.md
+++ b/docs/data-sources/enrollment_image.md
@@ -3,12 +3,12 @@
 page_title: "meltcloud_enrollment_image Data Source - meltcloud"
 subcategory: ""
 description: |-
-  An Enrollment Image https://docs.meltcloud.io/guides/enrollment-images.html creates bootable images to enroll your Machines into your meltcloud organization.
+  An Enrollment Image https://docs.meltcloud.io/tasks/enrollment-images creates bootable images to enroll your Machines into your meltcloud organization.
 ---
 
 # meltcloud_enrollment_image (Data Source)
 
-An [Enrollment Image](https://docs.meltcloud.io/guides/enrollment-images.html) creates bootable images to enroll your Machines into your meltcloud organization.
+An [Enrollment Image](https://docs.meltcloud.io/tasks/enrollment-images) creates bootable images to enroll your Machines into your meltcloud organization.
 
 ## Example Usage
 

--- a/docs/data-sources/machine_pool.md
+++ b/docs/data-sources/machine_pool.md
@@ -3,12 +3,12 @@
 page_title: "meltcloud_machine_pool Data Source - meltcloud"
 subcategory: ""
 description: |-
-  A Machine Pool https://docs.meltcloud.io/guides/machine-pools/create.html is a grouping entity for Machines (Kubernetes workers) which share a set of common configuration such as Kubelet version, disk or network configuration.
+  A Machine Pool https://docs.meltcloud.io/tasks/machine-pools/create is a grouping entity for Machines (Kubernetes workers) which share a set of common configuration such as Kubelet version, disk or network configuration.
 ---
 
 # meltcloud_machine_pool (Data Source)
 
-A [Machine Pool](https://docs.meltcloud.io/guides/machine-pools/create.html) is a grouping entity for Machines (Kubernetes workers) which share a set of common configuration such as Kubelet version, disk or network configuration.
+A [Machine Pool](https://docs.meltcloud.io/tasks/machine-pools/create) is a grouping entity for Machines (Kubernetes workers) which share a set of common configuration such as Kubelet version, disk or network configuration.
 
 ## Example Usage
 

--- a/docs/data-sources/network_profile.md
+++ b/docs/data-sources/network_profile.md
@@ -3,12 +3,12 @@
 page_title: "meltcloud_network_profile Data Source - meltcloud"
 subcategory: ""
 description: |-
-  A Network Profile https://docs.meltcloud.io/concepts/networking/network-profiles specifies the network configuration for Machines https://docs.meltcloud.io/concepts/machines in a Machine Pool https://docs.meltcloud.io/guides/machine-pools/create.html.
+  A Network Profile https://docs.meltcloud.io/concepts/networking/network-profiles specifies the network configuration for Machines https://docs.meltcloud.io/concepts/machines in a Machine Pool https://docs.meltcloud.io/tasks/machine-pools/create.
 ---
 
 # meltcloud_network_profile (Data Source)
 
-A [Network Profile](https://docs.meltcloud.io/concepts/networking/network-profiles) specifies the network configuration for [Machines](https://docs.meltcloud.io/concepts/machines) in a [Machine Pool](https://docs.meltcloud.io/guides/machine-pools/create.html).
+A [Network Profile](https://docs.meltcloud.io/concepts/networking/network-profiles) specifies the network configuration for [Machines](https://docs.meltcloud.io/concepts/machines) in a [Machine Pool](https://docs.meltcloud.io/tasks/machine-pools/create).
 
 
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -3,12 +3,12 @@
 page_title: "meltcloud_cluster Resource - meltcloud"
 subcategory: ""
 description: |-
-  A Cluster https://docs.meltcloud.io/guides/clusters/create.html in meltcloud consists of a Kubernetes Control Plane and associated objects like Machine Pools https://docs.meltcloud.io/guides/machine-pools/create.html (which hold assigned Machines https://docs.meltcloud.io/concepts/machines).
+  A Cluster https://docs.meltcloud.io/tasks/clusters/create in meltcloud consists of a Kubernetes Control Plane and associated objects like Machine Pools https://docs.meltcloud.io/tasks/machine-pools/create (which hold assigned Machines https://docs.meltcloud.io/concepts/machines).
 ---
 
 # meltcloud_cluster (Resource)
 
-A [Cluster](https://docs.meltcloud.io/guides/clusters/create.html) in meltcloud consists of a **Kubernetes Control Plane** and associated objects like [Machine Pools](https://docs.meltcloud.io/guides/machine-pools/create.html) (which hold assigned [Machines](https://docs.meltcloud.io/concepts/machines)).
+A [Cluster](https://docs.meltcloud.io/tasks/clusters/create) in meltcloud consists of a **Kubernetes Control Plane** and associated objects like [Machine Pools](https://docs.meltcloud.io/tasks/machine-pools/create) (which hold assigned [Machines](https://docs.meltcloud.io/concepts/machines)).
 
 ## Example Usage
 

--- a/docs/resources/elastic_fleet.md
+++ b/docs/resources/elastic_fleet.md
@@ -3,12 +3,12 @@
 page_title: "meltcloud_elastic_fleet Resource - meltcloud"
 subcategory: ""
 description: |-
-  An Elastic Fleet is a pool of compute resources on a cluster which can be sliced into Elastic Quotas for consumption by other organizations.
+  An Elastic Fleet https://docs.meltcloud.io/concepts/elastic-node-pools#elastic-fleet turns a Machine Pool into virtualization capacity. Resources can be allocated to organizations via Elastic Quotas https://docs.meltcloud.io/tasks/elastic-fleets/create-quota, and Elastic Nodes (virtual Kubernetes worker nodes) can be added to Clusters via Elastic Node Pools https://docs.meltcloud.io/tasks/elastic-node-pools/create.
 ---
 
 # meltcloud_elastic_fleet (Resource)
 
-An Elastic Fleet is a pool of compute resources on a cluster which can be sliced into Elastic Quotas for consumption by other organizations.
+An [Elastic Fleet](https://docs.meltcloud.io/concepts/elastic-node-pools#elastic-fleet) turns a Machine Pool into virtualization capacity. Resources can be allocated to organizations via [Elastic Quotas](https://docs.meltcloud.io/tasks/elastic-fleets/create-quota), and Elastic Nodes (virtual Kubernetes worker nodes) can be added to Clusters via [Elastic Node Pools](https://docs.meltcloud.io/tasks/elastic-node-pools/create).
 
 ## Example Usage
 

--- a/docs/resources/elastic_node_pool.md
+++ b/docs/resources/elastic_node_pool.md
@@ -3,12 +3,12 @@
 page_title: "meltcloud_elastic_node_pool Resource - meltcloud"
 subcategory: ""
 description: |-
-  An Elastic Node Pool is a grouping of Elastic Fleet nodes scheduled into a consuming organization's cluster, sized via node count and per-node resources.
+  An Elastic Node Pool https://docs.meltcloud.io/tasks/elastic-node-pools/create provisions Elastic Nodes (virtual Kubernetes worker nodes) from an Elastic Quota https://docs.meltcloud.io/tasks/elastic-fleets/create-quota and joins them to a Cluster.
 ---
 
 # meltcloud_elastic_node_pool (Resource)
 
-An Elastic Node Pool is a grouping of Elastic Fleet nodes scheduled into a consuming organization's cluster, sized via node count and per-node resources.
+An [Elastic Node Pool](https://docs.meltcloud.io/tasks/elastic-node-pools/create) provisions Elastic Nodes (virtual Kubernetes worker nodes) from an [Elastic Quota](https://docs.meltcloud.io/tasks/elastic-fleets/create-quota) and joins them to a Cluster.
 
 ## Example Usage
 

--- a/docs/resources/elastic_quota.md
+++ b/docs/resources/elastic_quota.md
@@ -3,12 +3,12 @@
 page_title: "meltcloud_elastic_quota Resource - meltcloud"
 subcategory: ""
 description: |-
-  An Elastic Quota grants a consuming organization a slice of an Elastic Fleet, expressed in cores, memory, and disk.
+  An Elastic Quota https://docs.meltcloud.io/tasks/elastic-fleets/create-quota allocates a portion of an Elastic Fleet https://docs.meltcloud.io/concepts/elastic-node-pools#elastic-fleet's resources (CPU, RAM, disk) to a consuming organization.
 ---
 
 # meltcloud_elastic_quota (Resource)
 
-An Elastic Quota grants a consuming organization a slice of an Elastic Fleet, expressed in cores, memory, and disk.
+An [Elastic Quota](https://docs.meltcloud.io/tasks/elastic-fleets/create-quota) allocates a portion of an [Elastic Fleet](https://docs.meltcloud.io/concepts/elastic-node-pools#elastic-fleet)'s resources (CPU, RAM, disk) to a consuming organization.
 
 ## Example Usage
 

--- a/docs/resources/enrollment_image.md
+++ b/docs/resources/enrollment_image.md
@@ -3,12 +3,12 @@
 page_title: "meltcloud_enrollment_image Resource - meltcloud"
 subcategory: ""
 description: |-
-  An Enrollment Image https://docs.meltcloud.io/guides/enrollment-images.html creates bootable images to enroll your Machines into your meltcloud organization.
+  An Enrollment Image https://docs.meltcloud.io/tasks/enrollment-images creates bootable images to enroll your Machines into your meltcloud organization.
 ---
 
 # meltcloud_enrollment_image (Resource)
 
-An [Enrollment Image](https://docs.meltcloud.io/guides/enrollment-images.html) creates bootable images to enroll your Machines into your meltcloud organization.
+An [Enrollment Image](https://docs.meltcloud.io/tasks/enrollment-images) creates bootable images to enroll your Machines into your meltcloud organization.
 
 ## Example Usage
 

--- a/docs/resources/machine.md
+++ b/docs/resources/machine.md
@@ -4,7 +4,7 @@ page_title: "meltcloud_machine Resource - meltcloud"
 subcategory: ""
 description: |-
   Machines https://docs.meltcloud.io/concepts/machines are bare-metal or virtualized computers designated as worker nodes for the Kubernetes Clusters provided by the meltcloud platform.
-  This resource pre-registers https://docs.meltcloud.io/guides/machines/add.html#pre-register Machines for a later boot.
+  This resource pre-registers https://docs.meltcloud.io/tasks/machines/add#pre-register Machines for a later boot.
   ~> Be aware that changing the name will cause a new Revision that will be applied immediately, causing a reboot of the Machine https://docs.meltcloud.io/concepts/machines#revisions.
 ---
 
@@ -12,7 +12,7 @@ description: |-
 
 [Machines](https://docs.meltcloud.io/concepts/machines) are bare-metal or virtualized computers designated as worker nodes for the Kubernetes Clusters provided by the meltcloud platform.
 
-This resource [pre-registers](https://docs.meltcloud.io/guides/machines/add.html#pre-register) Machines for a later boot.
+This resource [pre-registers](https://docs.meltcloud.io/tasks/machines/add#pre-register) Machines for a later boot.
 
 ~> Be aware that changing the name will cause a new [Revision that will be applied immediately, causing a reboot of the Machine](https://docs.meltcloud.io/concepts/machines#revisions).
 

--- a/docs/resources/machine_pool.md
+++ b/docs/resources/machine_pool.md
@@ -3,15 +3,15 @@
 page_title: "meltcloud_machine_pool Resource - meltcloud"
 subcategory: ""
 description: |-
-  A Machine Pool https://docs.meltcloud.io/guides/machine-pools/create.html is a grouping entity for Machines (Kubernetes workers) which share a set of common configuration such as Kubelet version, disk or network configuration.
-  ~> Be aware that changing the version or the network profile will cause a new Revision that will be applied immediately, causing a reboot of all Machines https://docs.meltcloud.io/guides/machine-pools/upgrade.html#revisions.
+  A Machine Pool https://docs.meltcloud.io/tasks/machine-pools/create is a grouping entity for Machines (Kubernetes workers) which share a set of common configuration such as Kubelet version, disk or network configuration.
+  ~> Be aware that changing the version or the network profile will cause a new Revision that will be rolled out immediately, causing a reboot of all Machines https://docs.meltcloud.io/tasks/machine-pools/upgrade.
 ---
 
 # meltcloud_machine_pool (Resource)
 
-A [Machine Pool](https://docs.meltcloud.io/guides/machine-pools/create.html) is a grouping entity for Machines (Kubernetes workers) which share a set of common configuration such as Kubelet version, disk or network configuration.
+A [Machine Pool](https://docs.meltcloud.io/tasks/machine-pools/create) is a grouping entity for Machines (Kubernetes workers) which share a set of common configuration such as Kubelet version, disk or network configuration.
 
-~> Be aware that changing the version or the network profile will cause a new [Revision that will be applied immediately, causing a reboot of all Machines](https://docs.meltcloud.io/guides/machine-pools/upgrade.html#revisions).
+~> Be aware that changing the version or the network profile will cause a new [Revision that will be rolled out immediately, causing a reboot of all Machines](https://docs.meltcloud.io/tasks/machine-pools/upgrade).
 
 ## Example Usage
 

--- a/docs/resources/network_profile.md
+++ b/docs/resources/network_profile.md
@@ -3,12 +3,12 @@
 page_title: "meltcloud_network_profile Resource - meltcloud"
 subcategory: ""
 description: |-
-  A Network Profile https://docs.meltcloud.io/concepts/networking/network-profiles specifies the network configuration for Machines https://docs.meltcloud.io/concepts/machines in a Machine Pool https://docs.meltcloud.io/guides/machine-pools/create.html.
+  A Network Profile https://docs.meltcloud.io/concepts/networking/network-profiles specifies the network configuration for Machines https://docs.meltcloud.io/concepts/machines in a Machine Pool https://docs.meltcloud.io/tasks/machine-pools/create.
 ---
 
 # meltcloud_network_profile (Resource)
 
-A [Network Profile](https://docs.meltcloud.io/concepts/networking/network-profiles) specifies the network configuration for [Machines](https://docs.meltcloud.io/concepts/machines) in a [Machine Pool](https://docs.meltcloud.io/guides/machine-pools/create.html).
+A [Network Profile](https://docs.meltcloud.io/concepts/networking/network-profiles) specifies the network configuration for [Machines](https://docs.meltcloud.io/concepts/machines) in a [Machine Pool](https://docs.meltcloud.io/tasks/machine-pools/create).
 
 ## Example Usage
 

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -58,7 +58,7 @@ func (r *ClusterResource) Metadata(ctx context.Context, req resource.MetadataReq
 	resp.TypeName = req.ProviderTypeName + "_cluster"
 }
 
-const clusterDesc string = "A [Cluster](https://docs.meltcloud.io/guides/clusters/create.html) in meltcloud consists of a **Kubernetes Control Plane** and associated objects like [Machine Pools](https://docs.meltcloud.io/guides/machine-pools/create.html) (which hold assigned [Machines](https://docs.meltcloud.io/concepts/machines))."
+const clusterDesc string = "A [Cluster](https://docs.meltcloud.io/tasks/clusters/create) in meltcloud consists of a **Kubernetes Control Plane** and associated objects like [Machine Pools](https://docs.meltcloud.io/tasks/machine-pools/create) (which hold assigned [Machines](https://docs.meltcloud.io/concepts/machines))."
 
 func clusterResourceAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{

--- a/internal/provider/elastic_fleet_resource.go
+++ b/internal/provider/elastic_fleet_resource.go
@@ -38,7 +38,7 @@ func (r *ElasticFleetResource) Metadata(ctx context.Context, req resource.Metada
 	resp.TypeName = req.ProviderTypeName + "_elastic_fleet"
 }
 
-const elasticFleetDesc = "An Elastic Fleet is a pool of compute resources on a cluster which can be sliced into Elastic Quotas for consumption by other organizations."
+const elasticFleetDesc = "An [Elastic Fleet](https://docs.meltcloud.io/concepts/elastic-node-pools#elastic-fleet) turns a Machine Pool into virtualization capacity. Resources can be allocated to organizations via [Elastic Quotas](https://docs.meltcloud.io/tasks/elastic-fleets/create-quota), and Elastic Nodes (virtual Kubernetes worker nodes) can be added to Clusters via [Elastic Node Pools](https://docs.meltcloud.io/tasks/elastic-node-pools/create)."
 
 func elasticFleetResourceAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{

--- a/internal/provider/elastic_node_pool_resource.go
+++ b/internal/provider/elastic_node_pool_resource.go
@@ -49,7 +49,7 @@ func (r *ElasticNodePoolResource) Metadata(ctx context.Context, req resource.Met
 	resp.TypeName = req.ProviderTypeName + "_elastic_node_pool"
 }
 
-const elasticNodePoolDesc = "An Elastic Node Pool is a grouping of Elastic Fleet nodes scheduled into a consuming organization's cluster, sized via node count and per-node resources."
+const elasticNodePoolDesc = "An [Elastic Node Pool](https://docs.meltcloud.io/tasks/elastic-node-pools/create) provisions Elastic Nodes (virtual Kubernetes worker nodes) from an [Elastic Quota](https://docs.meltcloud.io/tasks/elastic-fleets/create-quota) and joins them to a Cluster."
 
 func elasticNodePoolResourceAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{

--- a/internal/provider/elastic_quota_resource.go
+++ b/internal/provider/elastic_quota_resource.go
@@ -41,7 +41,7 @@ func (r *ElasticQuotaResource) Metadata(ctx context.Context, req resource.Metada
 	resp.TypeName = req.ProviderTypeName + "_elastic_quota"
 }
 
-const elasticQuotaDesc = "An Elastic Quota grants a consuming organization a slice of an Elastic Fleet, expressed in cores, memory, and disk."
+const elasticQuotaDesc = "An [Elastic Quota](https://docs.meltcloud.io/tasks/elastic-fleets/create-quota) allocates a portion of an [Elastic Fleet](https://docs.meltcloud.io/concepts/elastic-node-pools#elastic-fleet)'s resources (CPU, RAM, disk) to a consuming organization."
 
 func elasticQuotaResourceAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{

--- a/internal/provider/enrollment_image_resource.go
+++ b/internal/provider/enrollment_image_resource.go
@@ -55,7 +55,7 @@ func (r *EnrollmentImageResource) Metadata(ctx context.Context, req resource.Met
 	resp.TypeName = req.ProviderTypeName + "_enrollment_image"
 }
 
-const enrollmentImageDesc string = "An [Enrollment Image](https://docs.meltcloud.io/guides/enrollment-images.html) creates bootable images to enroll your Machines into your meltcloud organization."
+const enrollmentImageDesc string = "An [Enrollment Image](https://docs.meltcloud.io/tasks/enrollment-images) creates bootable images to enroll your Machines into your meltcloud organization."
 
 func enrollmentImageResourceAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{

--- a/internal/provider/machine_pool_resource.go
+++ b/internal/provider/machine_pool_resource.go
@@ -42,7 +42,7 @@ func (r *MachinePoolResource) Metadata(ctx context.Context, req resource.Metadat
 	resp.TypeName = req.ProviderTypeName + "_machine_pool"
 }
 
-const machinePoolDesc = "A [Machine Pool](https://docs.meltcloud.io/guides/machine-pools/create.html) is a grouping entity for Machines (Kubernetes workers) " +
+const machinePoolDesc = "A [Machine Pool](https://docs.meltcloud.io/tasks/machine-pools/create) is a grouping entity for Machines (Kubernetes workers) " +
 	"which share a set of common configuration such as Kubelet version, disk or network configuration."
 
 func machinePoolResourceAttributes() map[string]schema.Attribute {
@@ -83,7 +83,7 @@ func machinePoolResourceAttributes() map[string]schema.Attribute {
 func (r *MachinePoolResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: machinePoolDesc + "\n\n" +
-			"~> Be aware that changing the version or the network profile will cause a new [Revision that will be applied immediately, causing a reboot of all Machines](https://docs.meltcloud.io/guides/machine-pools/upgrade.html#revisions).",
+			"~> Be aware that changing the version or the network profile will cause a new [Revision that will be rolled out immediately, causing a reboot of all Machines](https://docs.meltcloud.io/tasks/machine-pools/upgrade).",
 
 		Attributes: machinePoolResourceAttributes(),
 	}

--- a/internal/provider/machine_resource.go
+++ b/internal/provider/machine_resource.go
@@ -94,7 +94,7 @@ func labelResourceAttributes() map[string]schema.Attribute {
 func (r *MachineResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: machineDesc + "\n\n" +
-			"This resource [pre-registers](https://docs.meltcloud.io/guides/machines/add.html#pre-register) Machines for a later boot.\n\n" +
+			"This resource [pre-registers](https://docs.meltcloud.io/tasks/machines/add#pre-register) Machines for a later boot.\n\n" +
 			"~> Be aware that changing the name will cause a new [Revision that will be applied immediately, causing a reboot of the Machine](https://docs.meltcloud.io/concepts/machines#revisions).",
 
 		Attributes: machineResourceAttributes(),

--- a/internal/provider/network_profile_resource.go
+++ b/internal/provider/network_profile_resource.go
@@ -49,7 +49,7 @@ func (r *NetworkProfileResource) Metadata(ctx context.Context, req resource.Meta
 	resp.TypeName = req.ProviderTypeName + "_network_profile"
 }
 
-const networkProfileDesc = "A [Network Profile](https://docs.meltcloud.io/concepts/networking/network-profiles) specifies the network configuration for [Machines](https://docs.meltcloud.io/concepts/machines) in a [Machine Pool](https://docs.meltcloud.io/guides/machine-pools/create.html)."
+const networkProfileDesc = "A [Network Profile](https://docs.meltcloud.io/concepts/networking/network-profiles) specifies the network configuration for [Machines](https://docs.meltcloud.io/concepts/machines) in a [Machine Pool](https://docs.meltcloud.io/tasks/machine-pools/create)."
 
 func networkProfileResourceAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{


### PR DESCRIPTION
## Summary
- Update all documentation links from `/guides/` to `/tasks/` to match restructured docs site
- Add docs links to elastic fleet, quota and node pool resource descriptions
- Align elastic resource descriptions with current docs wording
- Fix "applied" → "rolled out" in machine pool revision warning
- Regenerate provider docs

## Test plan
- [ ] Verify generated docs render correctly on Terraform registry
- [ ] Verify all links resolve to correct pages on docs.meltcloud.io