### PR TITLE
MEL-596: Expose disk mirroring on enrollment images

### DIFF
--- a/docs/data-sources/enrollment_image.md
+++ b/docs/data-sources/enrollment_image.md
@@ -40,8 +40,10 @@ data "meltcloud_enrollment_image" "example_name" {
 - `http_url_iso_arm64` (String, Sensitive) URL to download the ISO for ARM64 via HTTP
 - `https_url_iso_amd64` (String, Sensitive) URL to download the ISO for AMD64 via HTTPS
 - `https_url_iso_arm64` (String, Sensitive) URL to download the ISO for ARM64 via HTTPS
-- `install_disk_device` (String) Device path (i.e. /dev/vda) of the disk where system should be installed to
+- `install_disk_device` (String) Device path of the disk where the system should be installed to. Use a `/dev/disk/by-path/` path (i.e. `/dev/disk/by-path/pci-0000:00:17.0-ata-1`) rather than a kernel name such as `/dev/sda`, as those can change between boots; see [Choosing Disk Devices](https://docs.meltcloud.io/tasks/enrollment-images#choosing-disk-devices). If not specified, the disk is auto-detected, which only works if Linux sees exactly one block device (i.e. a single attached disk, or a Dell BOSS RAID pair that shows up as one). It must be specified if `install_disk_mirror` is enabled.
 - `install_disk_force_overwrite` (Boolean) Force overwrite disk if it contains unknown data
+- `install_disk_mirror` (Boolean) Whether the install disk is mirrored onto a second disk (RAID1) for redundancy. Requires `install_disk_device` and `install_disk_mirror_device` to be set, since auto-detection cannot decide which of two disks is the primary and which the mirror.
+- `install_disk_mirror_device` (String) Device path of the disk used as the mirror, i.e. `/dev/disk/by-path/pci-0000:00:17.0-ata-2`. Required (and only allowed) if `install_disk_mirror` is enabled, and must differ from `install_disk_device`. It is never auto-detected.
 - `last_used_at` (String) Timestamp when the image was last used for an enrollment
 - `status` (String) Status of the Enrollment Image
 - `vlan` (Number) The VLAN to use as the enrollment network

--- a/docs/resources/enrollment_image.md
+++ b/docs/resources/enrollment_image.md
@@ -20,8 +20,18 @@ resource "time_offset" "in_a_day" {
 resource "meltcloud_enrollment_image" "example" {
   name                = "my-image"
   expires_at          = time_offset.in_a_day.rfc3339
-  install_disk_device = "/dev/vda"
+  install_disk_device = "/dev/disk/by-path/pci-0000:00:17.0-ata-1"
   vlan                = 100
+}
+
+# a mirrored install requires both disks to be named explicitly;
+# by-path devices describe the slot, so one image works for a whole fleet of identical servers
+resource "meltcloud_enrollment_image" "mirrored" {
+  name                       = "my-mirrored-image"
+  expires_at                 = time_offset.in_a_day.rfc3339
+  install_disk_device        = "/dev/disk/by-path/pci-0000:00:17.0-ata-1"
+  install_disk_mirror        = true
+  install_disk_mirror_device = "/dev/disk/by-path/pci-0000:00:17.0-ata-2"
 }
 ```
 
@@ -31,13 +41,15 @@ resource "meltcloud_enrollment_image" "example" {
 ### Required
 
 - `expires_at` (String) Timestamp when the image should expire
-- `install_disk_device` (String) Device path (i.e. /dev/vda) of the disk where system should be installed to
 - `name` (String) Name of the Enrollment Image, not case-sensitive. Must be unique within the organization.
 
 ### Optional
 
 - `enable_http` (Boolean) Whether the images should be downloadable via insecure HTTP
+- `install_disk_device` (String) Device path of the disk where the system should be installed to. Use a `/dev/disk/by-path/` path (i.e. `/dev/disk/by-path/pci-0000:00:17.0-ata-1`) rather than a kernel name such as `/dev/sda`, as those can change between boots; see [Choosing Disk Devices](https://docs.meltcloud.io/tasks/enrollment-images#choosing-disk-devices). If not specified, the disk is auto-detected, which only works if Linux sees exactly one block device (i.e. a single attached disk, or a Dell BOSS RAID pair that shows up as one). It must be specified if `install_disk_mirror` is enabled.
 - `install_disk_force_overwrite` (Boolean) Force overwrite disk if it contains unknown data
+- `install_disk_mirror` (Boolean) Whether the install disk is mirrored onto a second disk (RAID1) for redundancy. Requires `install_disk_device` and `install_disk_mirror_device` to be set, since auto-detection cannot decide which of two disks is the primary and which the mirror.
+- `install_disk_mirror_device` (String) Device path of the disk used as the mirror, i.e. `/dev/disk/by-path/pci-0000:00:17.0-ata-2`. Required (and only allowed) if `install_disk_mirror` is enabled, and must differ from `install_disk_device`. It is never auto-detected.
 - `vlan` (Number) The VLAN to use as the enrollment network
 
 ### Read-Only

--- a/examples/resources/meltcloud_enrollment_image/resource.tf
+++ b/examples/resources/meltcloud_enrollment_image/resource.tf
@@ -5,6 +5,16 @@ resource "time_offset" "in_a_day" {
 resource "meltcloud_enrollment_image" "example" {
   name                = "my-image"
   expires_at          = time_offset.in_a_day.rfc3339
-  install_disk_device = "/dev/vda"
+  install_disk_device = "/dev/disk/by-path/pci-0000:00:17.0-ata-1"
   vlan                = 100
+}
+
+# a mirrored install requires both disks to be named explicitly;
+# by-path devices describe the slot, so one image works for a whole fleet of identical servers
+resource "meltcloud_enrollment_image" "mirrored" {
+  name                       = "my-mirrored-image"
+  expires_at                 = time_offset.in_a_day.rfc3339
+  install_disk_device        = "/dev/disk/by-path/pci-0000:00:17.0-ata-1"
+  install_disk_mirror        = true
+  install_disk_mirror_device = "/dev/disk/by-path/pci-0000:00:17.0-ata-2"
 }

--- a/internal/client/enrollment_image.go
+++ b/internal/client/enrollment_image.go
@@ -24,8 +24,10 @@ type EnrollmentImage struct {
 	Name                      string     `json:"name"`
 	ExpiresAt                 time.Time  `json:"expires_at"`
 	Status                    string     `json:"status"`
-	InstallDiskDevice         string     `json:"install_disk_device"`
+	InstallDiskDevice         *string    `json:"install_disk_device"`
 	InstallDiskForceOverwrite bool       `json:"install_disk_force_overwrite"`
+	InstallDiskMirror         bool       `json:"install_disk_mirror"`
+	InstallDiskMirrorDevice   *string    `json:"install_disk_mirror_device"`
 	VLAN                      *int64     `json:"vlan"`
 	EnableHTTP                bool       `json:"enable_http"`
 	HTTPURLISOAMD64           string     `json:"http_url_iso_amd64"`
@@ -38,8 +40,10 @@ type EnrollmentImage struct {
 type EnrollmentImageCreateInput struct {
 	Name                      string    `json:"name"`
 	ExpiresAt                 time.Time `json:"expires_at"`
-	InstallDiskDevice         string    `json:"install_disk_device"`
+	InstallDiskDevice         *string   `json:"install_disk_device,omitempty"`
 	InstallDiskForceOverwrite *bool     `json:"install_disk_force_overwrite"`
+	InstallDiskMirror         *bool     `json:"install_disk_mirror"`
+	InstallDiskMirrorDevice   *string   `json:"install_disk_mirror_device,omitempty"`
 	VLAN                      *int64    `json:"vlan"`
 	EnableHTTP                *bool     `json:"enable_http"`
 }

--- a/internal/provider/enrollment_image_data_source.go
+++ b/internal/provider/enrollment_image_data_source.go
@@ -34,6 +34,8 @@ type EnrollmentImageDataSourceModel struct {
 	ExpiresAt                 timetypes.RFC3339 `tfsdk:"expires_at"`
 	InstallDiskDevice         types.String      `tfsdk:"install_disk_device"`
 	InstallDiskForceOverwrite types.Bool        `tfsdk:"install_disk_force_overwrite"`
+	InstallDiskMirror         types.Bool        `tfsdk:"install_disk_mirror"`
+	InstallDiskMirrorDevice   types.String      `tfsdk:"install_disk_mirror_device"`
 	VLAN                      types.Int64       `tfsdk:"vlan"`
 	EnableHTTP                types.Bool        `tfsdk:"enable_http"`
 	HTTPURLISOAMD64           types.String      `tfsdk:"http_url_iso_amd64"`
@@ -83,6 +85,14 @@ func (d *EnrollmentImageDataSource) Schema(ctx context.Context, req datasource.S
 			},
 			"install_disk_force_overwrite": schema.BoolAttribute{
 				MarkdownDescription: enrollmentImageResourceAttributes()["install_disk_force_overwrite"].GetMarkdownDescription(),
+				Computed:            true,
+			},
+			"install_disk_mirror": schema.BoolAttribute{
+				MarkdownDescription: enrollmentImageResourceAttributes()["install_disk_mirror"].GetMarkdownDescription(),
+				Computed:            true,
+			},
+			"install_disk_mirror_device": schema.StringAttribute{
+				MarkdownDescription: enrollmentImageResourceAttributes()["install_disk_mirror_device"].GetMarkdownDescription(),
 				Computed:            true,
 			},
 			"vlan": schema.Int64Attribute{
@@ -181,10 +191,12 @@ func (d *EnrollmentImageDataSource) Read(ctx context.Context, req datasource.Rea
 	data.Name = types.StringValue(enrollmentImage.Name)
 	data.Status = types.StringValue(enrollmentImage.Status)
 	data.ExpiresAt = timetypes.NewRFC3339TimeValue(enrollmentImage.ExpiresAt)
-	data.InstallDiskDevice = types.StringValue(enrollmentImage.InstallDiskDevice)
+	data.InstallDiskDevice = types.StringPointerValue(enrollmentImage.InstallDiskDevice)
 	data.VLAN = types.Int64PointerValue(enrollmentImage.VLAN)
 	data.EnableHTTP = types.BoolValue(enrollmentImage.EnableHTTP)
 	data.InstallDiskForceOverwrite = types.BoolValue(enrollmentImage.InstallDiskForceOverwrite)
+	data.InstallDiskMirror = types.BoolValue(enrollmentImage.InstallDiskMirror)
+	data.InstallDiskMirrorDevice = types.StringPointerValue(enrollmentImage.InstallDiskMirrorDevice)
 	data.HTTPURLISOAMD64 = types.StringValue(enrollmentImage.HTTPURLISOAMD64)
 	data.HTTPURLISOARM64 = types.StringValue(enrollmentImage.HTTPURLISOARM64)
 	data.HTTPSURLISOAMD64 = types.StringValue(enrollmentImage.HTTPSURLISOAMD64)

--- a/internal/provider/enrollment_image_resource.go
+++ b/internal/provider/enrollment_image_resource.go
@@ -21,6 +21,7 @@ import (
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &EnrollmentImageResource{}
 var _ resource.ResourceWithImportState = &EnrollmentImageResource{}
+var _ resource.ResourceWithValidateConfig = &EnrollmentImageResource{}
 
 func NewEnrollmentImageResource() resource.Resource {
 	return &EnrollmentImageResource{}
@@ -38,6 +39,8 @@ type EnrollmentImageResourceModel struct {
 	ExpiresAt                 timetypes.RFC3339 `tfsdk:"expires_at"`
 	InstallDiskDevice         types.String      `tfsdk:"install_disk_device"`
 	InstallDiskForceOverwrite types.Bool        `tfsdk:"install_disk_force_overwrite"`
+	InstallDiskMirror         types.Bool        `tfsdk:"install_disk_mirror"`
+	InstallDiskMirrorDevice   types.String      `tfsdk:"install_disk_mirror_device"`
 	VLAN                      types.Int64       `tfsdk:"vlan"`
 	EnableHTTP                types.Bool        `tfsdk:"enable_http"`
 	HTTPURLISOAMD64           types.String      `tfsdk:"http_url_iso_amd64"`
@@ -78,8 +81,8 @@ func enrollmentImageResourceAttributes() map[string]schema.Attribute {
 			},
 		},
 		"install_disk_device": schema.StringAttribute{
-			Required:            true,
-			MarkdownDescription: "Device path (i.e. /dev/vda) of the disk where system should be installed to",
+			Optional:            true,
+			MarkdownDescription: "Device path of the disk where the system should be installed to. Use a `/dev/disk/by-path/` path (i.e. `/dev/disk/by-path/pci-0000:00:17.0-ata-1`) rather than a kernel name such as `/dev/sda`, as those can change between boots; see [Choosing Disk Devices](https://docs.meltcloud.io/tasks/enrollment-images#choosing-disk-devices). If not specified, the disk is auto-detected, which only works if Linux sees exactly one block device (i.e. a single attached disk, or a Dell BOSS RAID pair that shows up as one). It must be specified if `install_disk_mirror` is enabled.",
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),
 			},
@@ -90,6 +93,21 @@ func enrollmentImageResourceAttributes() map[string]schema.Attribute {
 			MarkdownDescription: "Force overwrite disk if it contains unknown data",
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.RequiresReplace(),
+			},
+		},
+		"install_disk_mirror": schema.BoolAttribute{
+			Optional:            true,
+			Computed:            true,
+			MarkdownDescription: "Whether the install disk is mirrored onto a second disk (RAID1) for redundancy. Requires `install_disk_device` and `install_disk_mirror_device` to be set, since auto-detection cannot decide which of two disks is the primary and which the mirror.",
+			PlanModifiers: []planmodifier.Bool{
+				boolplanmodifier.RequiresReplace(),
+			},
+		},
+		"install_disk_mirror_device": schema.StringAttribute{
+			Optional:            true,
+			MarkdownDescription: "Device path of the disk used as the mirror, i.e. `/dev/disk/by-path/pci-0000:00:17.0-ata-2`. Required (and only allowed) if `install_disk_mirror` is enabled, and must differ from `install_disk_device`. It is never auto-detected.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
 			},
 		},
 		"vlan": schema.Int64Attribute{
@@ -144,6 +162,55 @@ func (r *EnrollmentImageResource) Schema(ctx context.Context, req resource.Schem
 	}
 }
 
+// ValidateConfig enforces the disk combinations the machine agent accepts: a mirrored install
+// cannot auto-detect its disks, because auto-detection cannot decide which of two disks is the
+// primary and which the copy.
+func (r *EnrollmentImageResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data EnrollmentImageResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.InstallDiskMirror.IsUnknown() {
+		return
+	}
+
+	if data.InstallDiskMirror.ValueBool() {
+		if data.InstallDiskDevice.IsNull() {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("install_disk_device"),
+				"Missing Attribute Configuration",
+				"install_disk_device must be set if install_disk_mirror is enabled, as the disks cannot be auto-detected for a mirrored install.",
+			)
+		}
+
+		if data.InstallDiskMirrorDevice.IsNull() {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("install_disk_mirror_device"),
+				"Missing Attribute Configuration",
+				"install_disk_mirror_device must be set if install_disk_mirror is enabled, as the disks cannot be auto-detected for a mirrored install.",
+			)
+		}
+
+		if !data.InstallDiskDevice.IsUnknown() && !data.InstallDiskMirrorDevice.IsUnknown() &&
+			!data.InstallDiskDevice.IsNull() && data.InstallDiskDevice.Equal(data.InstallDiskMirrorDevice) {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("install_disk_mirror_device"),
+				"Invalid Attribute Combination",
+				"install_disk_mirror_device must differ from install_disk_device.",
+			)
+		}
+	} else if !data.InstallDiskMirrorDevice.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("install_disk_mirror_device"),
+			"Invalid Attribute Combination",
+			"install_disk_mirror_device can only be set if install_disk_mirror is enabled.",
+		)
+	}
+}
+
 func (r *EnrollmentImageResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.
 	if req.ProviderData == nil {
@@ -188,6 +255,21 @@ func (r *EnrollmentImageResource) Create(ctx context.Context, req resource.Creat
 		installDiskForceOverwrite = data.InstallDiskForceOverwrite.ValueBoolPointer()
 	}
 
+	var installDiskMirror *bool
+	if !data.InstallDiskMirror.IsNull() && !data.InstallDiskMirror.IsUnknown() {
+		installDiskMirror = data.InstallDiskMirror.ValueBoolPointer()
+	}
+
+	var installDiskDevice *string
+	if !data.InstallDiskDevice.IsNull() && !data.InstallDiskDevice.IsUnknown() {
+		installDiskDevice = data.InstallDiskDevice.ValueStringPointer()
+	}
+
+	var installDiskMirrorDevice *string
+	if !data.InstallDiskMirrorDevice.IsNull() && !data.InstallDiskMirrorDevice.IsUnknown() {
+		installDiskMirrorDevice = data.InstallDiskMirrorDevice.ValueStringPointer()
+	}
+
 	var enableHTTP *bool
 	if !data.EnableHTTP.IsNull() && !data.EnableHTTP.IsUnknown() {
 		enableHTTP = data.EnableHTTP.ValueBoolPointer()
@@ -196,8 +278,10 @@ func (r *EnrollmentImageResource) Create(ctx context.Context, req resource.Creat
 	enrollmentImageCreateInput := &client.EnrollmentImageCreateInput{
 		Name:                      data.Name.ValueString(),
 		ExpiresAt:                 expiresAt.UTC(),
-		InstallDiskDevice:         data.InstallDiskDevice.ValueString(),
+		InstallDiskDevice:         installDiskDevice,
 		InstallDiskForceOverwrite: installDiskForceOverwrite,
+		InstallDiskMirror:         installDiskMirror,
+		InstallDiskMirrorDevice:   installDiskMirrorDevice,
 		VLAN:                      vlan,
 		EnableHTTP:                enableHTTP,
 	}
@@ -250,7 +334,6 @@ func (r *EnrollmentImageResource) Read(ctx context.Context, req resource.ReadReq
 
 	data.Name = types.StringValue(result.EnrollmentImage.Name)
 	data.ExpiresAt = timetypes.NewRFC3339TimeValue(result.EnrollmentImage.ExpiresAt.UTC())
-	data.InstallDiskDevice = types.StringValue(result.EnrollmentImage.InstallDiskDevice)
 	r.setValues(result.EnrollmentImage, &data)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -263,7 +346,10 @@ func (r *EnrollmentImageResource) Update(ctx context.Context, req resource.Updat
 func (r *EnrollmentImageResource) setValues(result *client.EnrollmentImage, data *EnrollmentImageResourceModel) {
 	data.VLAN = types.Int64PointerValue(result.VLAN)
 	data.EnableHTTP = types.BoolValue(result.EnableHTTP)
+	data.InstallDiskDevice = types.StringPointerValue(result.InstallDiskDevice)
 	data.InstallDiskForceOverwrite = types.BoolValue(result.InstallDiskForceOverwrite)
+	data.InstallDiskMirror = types.BoolValue(result.InstallDiskMirror)
+	data.InstallDiskMirrorDevice = types.StringPointerValue(result.InstallDiskMirrorDevice)
 	data.HTTPURLISOAMD64 = types.StringValue(result.HTTPURLISOAMD64)
 	data.HTTPURLISOARM64 = types.StringValue(result.HTTPURLISOARM64)
 	data.HTTPSURLISOAMD64 = types.StringValue(result.HTTPSURLISOAMD64)


### PR DESCRIPTION
Exposes the disk mirroring fields added in meltcloud/foundry#308 on the enrollment image resource and data source.

## Changes

- new `install_disk_mirror` (bool) and `install_disk_mirror_device` (string) attributes on the resource and data source
- `install_disk_device` is now optional, as the API auto-detects the install disk when it is left empty; it is read back as null instead of an empty string
- `ValidateConfig` mirrors the API validations, so bad combinations fail at plan time instead of on create:
  - mirroring requires both `install_disk_device` and `install_disk_mirror_device` (auto-detection cannot decide which of two disks is the primary and which the mirror)
  - `install_disk_mirror_device` is only allowed with mirroring enabled
  - both devices must differ
- docs and examples now use stable `/dev/disk/by-path/` devices instead of `/dev/vda`, in line with the meltcloud docs (`by-id` would require one enrollment image per host)

## Testing

Ran against a local foundry with all variations:

- auto-detect (no disk fields), explicit install disk, and full mirror all apply successfully and re-plan clean (no perpetual diff, auto-detected device stays null)
- data source returns the new fields for both a mirrored and an auto-detect image
- all three invalid combinations are rejected at plan time
- changing `install_disk_mirror_device` forces replacement; import of a mirrored image populates all fields and plans clean